### PR TITLE
bugfix: mesh doesn't recalculate when moved

### DIFF
--- a/src/ofxBaseSurface.h
+++ b/src/ofxBaseSurface.h
@@ -14,6 +14,7 @@ public:
     virtual void draw(){};
     virtual void setVertex(int index, ofVec2f p){};
     virtual void setTexCoord(int index, ofVec2f t){};
+    virtual void moveBy(ofVec2f v){};
     virtual int getType(){};
     virtual bool hitTest(ofVec2f p){};
     virtual ofPolyline getHitArea(){};

--- a/src/ofxProjectionEditor.cpp
+++ b/src/ofxProjectionEditor.cpp
@@ -209,10 +209,11 @@ void ofxProjectionEditor::moveSelectedSurface(ofVec2f by)
 {
     if ( surfaceManager == NULL ) return;
     if ( surfaceManager->getSelectedSurface() == NULL ) return;
-    vector<ofVec3f>& vertices = surfaceManager->getSelectedSurface()->getVertices();
+    surfaceManager->getSelectedSurface()->moveBy(by);
+    /*vector<ofVec3f>& vertices = surfaceManager->getSelectedSurface()->getVertices();
     for (int i=0; i<vertices.size(); i++) {
         vertices[i] += by;
-    }
+    }*/
     updateJoints();
 }
 

--- a/src/ofxQuadSurface.cpp
+++ b/src/ofxQuadSurface.cpp
@@ -106,6 +106,15 @@ void ofxQuadSurface::setTexCoord(int index, ofVec2f t)
     calculate4dTextureCoords();
 }
 
+void ofxQuadSurface::moveBy(ofVec2f v)
+{
+    vector<ofVec3f>& vertices = getVertices();
+    for (int i=0; i<vertices.size(); i++) {
+        vertices[i] += v;
+    }
+    calculate4dTextureCoords();
+}
+
 int ofxQuadSurface::getType()
 {
     return ofxSurfaceType::QUAD_SURFACE;

--- a/src/ofxQuadSurface.h
+++ b/src/ofxQuadSurface.h
@@ -20,6 +20,7 @@ public:
     void draw();
     void setVertex( int index, ofVec2f p );
     void setTexCoord( int index, ofVec2f t );
+    void moveBy(ofVec2f v);
     
     int getType();
     bool hitTest(ofVec2f p);

--- a/src/ofxTriangleSurface.cpp
+++ b/src/ofxTriangleSurface.cpp
@@ -72,6 +72,14 @@ void ofxTriangleSurface::setTexCoord(int index, ofVec2f t)
     mesh.setTexCoord(index, t);
 }
 
+void ofxTriangleSurface::moveBy(ofVec2f v)
+{
+    vector<ofVec3f>& vertices = getVertices();
+    for (int i=0; i<vertices.size(); i++) {
+        vertices[i] += v;
+    }
+}
+
 int ofxTriangleSurface::getType()
 {
     return ofxSurfaceType::TRIANGLE_SURFACE;

--- a/src/ofxTriangleSurface.h
+++ b/src/ofxTriangleSurface.h
@@ -16,6 +16,7 @@ public:
     void draw();
     void setVertex( int index, ofVec2f p );
     void setTexCoord( int index, ofVec2f t );
+    void moveBy(ofVec2f v);
     
     int getType();
     bool hitTest(ofVec2f p);


### PR DESCRIPTION
I added the method moveBy in ofxBaseSurface and implemented in Quad and Triangle. Now each shape has the ability to do work, when it's modified.
