### PR TITLE
aligned more closely with openFrameworks paradigm

### DIFF
--- a/src/MediaServer/MediaServer.cpp
+++ b/src/MediaServer/MediaServer.cpp
@@ -340,7 +340,9 @@ void MediaServer::addFboSource(FboSource * fboSource){
     
     // It is important to run the setup of the FBO
     // source from outside as we can see here.
+    fboSource->beginFbo();
     fboSource->setup();
+    fboSource->endFbo();
 }
 
 BaseSource * MediaServer::loadFboSource(string & fboSourceName){

--- a/src/Sources/FboSource.cpp
+++ b/src/Sources/FboSource.cpp
@@ -24,6 +24,22 @@ void FboSource::updateFbo(){
 	update();
 }
 
+void FboSource::beginFbo(){
+    if(fbo == 0 || !fbo->isAllocated()){
+        ofLogWarning("FboSource") << "FBO not allocated";
+        return;
+    }
+    fbo->begin();
+}
+
+void FboSource::endFbo(){
+    if(fbo == 0 || !fbo->isAllocated()){
+        ofLogWarning("FboSource") << "FBO not allocated";
+        return;
+    }
+    fbo->end();
+}
+
 void FboSource::drawFbo(){
 	if(fbo == 0 || !fbo->isAllocated()){
 		ofLogWarning("FboSource") << "FBO not allocated";

--- a/src/Sources/FboSource.h
+++ b/src/Sources/FboSource.h
@@ -33,6 +33,10 @@ class FboSource : public BaseSource {
 		// App listeners
 		void setDisableDraw(bool b); // Use in cases with external ofFbo
 
+        // fbo accessor functions to allow us to wrap any function with begin/end calls to fbo
+        void beginFbo();
+        void endFbo();
+
 	protected:
 		ofFbo * fbo;
 		void allocate(int width, int height);

--- a/src/Surfaces/SurfaceManager.cpp
+++ b/src/Surfaces/SurfaceManager.cpp
@@ -462,8 +462,24 @@ void SurfaceManager::setPreset(unsigned int i){
 	
 	_activePresetIndex = i;
 
+    //when preset it changed, call reset on all sources, if it's defined
     for (int i=0; i<_presets[_activePresetIndex]->getSurfaces().size(); i++){
+
+        //if source is of type FBO then cast it from BaseSource to FboSource and call the beginFbo function
+        if (_presets[_activePresetIndex]->getSurfaces()[i]->getSource()->getType() == SourceType::SOURCE_TYPE_FBO){
+            FboSource *fboSource;
+            fboSource = (FboSource*)_presets[_activePresetIndex]->getSurfaces()[i]->getSource();
+            fboSource->beginFbo();
+        }
+
         _presets[_activePresetIndex]->getSurfaces()[i]->getSource()->reset();
+
+        //if source is of type FBO then cast it from BaseSource to FboSource and call the endFbo function
+        if (_presets[_activePresetIndex]->getSurfaces()[i]->getSource()->getType() == SourceType::SOURCE_TYPE_FBO){
+            FboSource *fboSource;
+            fboSource = (FboSource*)_presets[_activePresetIndex]->getSurfaces()[i]->getSource();
+            fboSource->endFbo();
+        }
     }
 }
 


### PR DESCRIPTION
issue: setup() and reset() functions required a call within the fboSource of
```
fbo->begin();
//do something
fbo->end();
```
in order to actually draw something. Otherwise any drawing was not applied.
`draw()` was already surrounded by such calls. To make it more compatible with openFrameworks which allows drawing in `setup()` etc. i did:

* added functions in FboSource to allow me to make calls to begin/end Fbo.
* MediaServer class surrounds calls to FboSource `setup()` with begin/end fbo
* When SurfaceManager changes presets, calls to FboSource `reset()` are surrounded with begin/end fbo __if__ the source is FboSource. Had to do a bit of typecasting in that case in order to make it work.