### PR TITLE
fixed malloc error when setup() was called

### DIFF
--- a/src/MediaServer/MediaServer.cpp
+++ b/src/MediaServer/MediaServer.cpp
@@ -340,9 +340,7 @@ void MediaServer::addFboSource(FboSource * fboSource){
     
     // It is important to run the setup of the FBO
     // source from outside as we can see here.
-    fboSource->beginFbo();
     fboSource->setup();
-    fboSource->endFbo();
 }
 
 BaseSource * MediaServer::loadFboSource(string & fboSourceName){


### PR DESCRIPTION
The Media server `addSource(FboSource * fboSource)` function makes this call: `fboSource->setup();`

In a recent fix, I added a call to the source's `fbo->begin()` before the call to `setup()` as well as an `fbo->end()` after that.. This was done in order to allow drawing inside the `setup()` function of the source.

__Problem:__ it's the `setup()` function that does the allocating of the buffer. Therefore, you can't place a call to begin drawing on the fbo before the setup has run and the FboSource has been allocated.

I removed the beginFbo/endFbo calls from the MediaServer. For the moment, if you want to draw inside the `setup()` function you'd have to  manually call the calls to fbo begin such as:
```
this->beginFbo();
setupBalls();
ofClear(255,0,0);
this->endFbo();
```