### PR TITLE
Always ofEnableAlphaBlending

### DIFF
--- a/src/Surfaces/SurfaceStack.cpp
+++ b/src/Surfaces/SurfaceStack.cpp
@@ -30,9 +30,8 @@ void SurfaceStack::draw(){
 		if(_surfaces[i]->getSource()->getType() == SourceType::SOURCE_TYPE_FBO){
 			glEnable(GL_BLEND);
 			glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-		}else{
-			ofEnableAlphaBlending();
 		}
+		ofEnableAlphaBlending();
 		
 		_surfaces[i]->draw();
 	}


### PR DESCRIPTION
I think this fixes #153 as it means I can use a mask (of any shape) on a rect surface so I no longer need the circle surface. However I'm not sure why it was enabled before, so need insight as to what effects this might have on other people's code. Thanks