### PR TITLE
Set source paths to relative for all Targets but Raspi

### DIFF
--- a/src/Application/SettingsLoader.cpp
+++ b/src/Application/SettingsLoader.cpp
@@ -78,10 +78,16 @@ bool SettingsLoader::load(
 							source = mediaServer.loadMedia(sourceName, typeEnum);
 						}else{
 				
+							// relative pathss as default, absolute Paths for RASPI
+							bool absolutePathSwitch = false;
+							#ifdef TARGET_RASPBERRY_PI
+								absolutePathSwitch = true;
+							#endif
+
 							// Construct full path
 							std::string dir = mediaServer.getDefaultMediaDir(typeEnum);
 							std::stringstream pathss;
-							pathss << ofToDataPath(dir, true) << sourceName;
+							pathss << ofToDataPath(dir, absolutePathSwitch) << sourceName;
 							std::string sourcePath = pathss.str();
 				
 							// Check if file exists

--- a/src/MediaServer/MediaServer.cpp
+++ b/src/MediaServer/MediaServer.cpp
@@ -1,21 +1,29 @@
 #include "MediaServer.h"
 
+
+
+
 namespace ofx {
 namespace piMapper {
 
-MediaServer::MediaServer():
-	piVideoWatcher(PI_IMAGES_DIR, SourceType::SOURCE_TYPE_VIDEO),
-	usb0VideoWatcher(USB0_VIDEOS_DIR, SourceType::SOURCE_TYPE_VIDEO),
-	usb1VideoWatcher(USB1_VIDEOS_DIR, SourceType::SOURCE_TYPE_VIDEO),
-	usb2VideoWatcher(USB2_VIDEOS_DIR, SourceType::SOURCE_TYPE_VIDEO),
-	usb3VideoWatcher(USB3_VIDEOS_DIR, SourceType::SOURCE_TYPE_VIDEO),
-    piImageWatcher(PI_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
-	usb0ImageWatcher(USB0_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
-	usb1ImageWatcher(USB1_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
-	usb2ImageWatcher(USB2_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
-	usb3ImageWatcher(USB3_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
-	imageWatcher(ofToDataPath(DEFAULT_IMAGES_DIR, true), SourceType::SOURCE_TYPE_IMAGE),
-	videoWatcher(ofToDataPath(DEFAULT_VIDEOS_DIR, true), SourceType::SOURCE_TYPE_VIDEO)
+	// relative pathss as default, absolute Paths for RASPI
+	bool absolutePathSwitch = false;
+	#ifdef TARGET_RASPBERRY_PI
+		absolutePathSwitch = true;
+	#endif
+	MediaServer::MediaServer() :
+		piVideoWatcher(PI_IMAGES_DIR, SourceType::SOURCE_TYPE_VIDEO),
+		usb0VideoWatcher(USB0_VIDEOS_DIR, SourceType::SOURCE_TYPE_VIDEO),
+		usb1VideoWatcher(USB1_VIDEOS_DIR, SourceType::SOURCE_TYPE_VIDEO),
+		usb2VideoWatcher(USB2_VIDEOS_DIR, SourceType::SOURCE_TYPE_VIDEO),
+		usb3VideoWatcher(USB3_VIDEOS_DIR, SourceType::SOURCE_TYPE_VIDEO),
+		piImageWatcher(PI_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
+		usb0ImageWatcher(USB0_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
+		usb1ImageWatcher(USB1_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
+		usb2ImageWatcher(USB2_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
+		usb3ImageWatcher(USB3_IMAGES_DIR, SourceType::SOURCE_TYPE_IMAGE),
+		imageWatcher(ofToDataPath(DEFAULT_IMAGES_DIR, absolutePathSwitch), SourceType::SOURCE_TYPE_IMAGE),
+		videoWatcher(ofToDataPath(DEFAULT_VIDEOS_DIR, absolutePathSwitch), SourceType::SOURCE_TYPE_VIDEO)
 {
 	// By initialising all above we also copy files from external media
 	// to the ofxPiMapper storage.

--- a/src/MediaServer/MediaServer.cpp
+++ b/src/MediaServer/MediaServer.cpp
@@ -1,15 +1,14 @@
 #include "MediaServer.h"
 
 
-
-
 namespace ofx {
 namespace piMapper {
 
 	// relative pathss as default, absolute Paths for RASPI
-	bool absolutePathSwitch = false;
 	#ifdef TARGET_RASPBERRY_PI
-		absolutePathSwitch = true;
+		bool absolutePathSwitch = true;
+	#else
+		bool absolutePathSwitch = false;
 	#endif
 	MediaServer::MediaServer() :
 		piVideoWatcher(PI_IMAGES_DIR, SourceType::SOURCE_TYPE_VIDEO),

--- a/src/ofxPiMapper.cpp
+++ b/src/ofxPiMapper.cpp
@@ -1,6 +1,5 @@
 #include "ofxPiMapper.h"
 
-
 ofxPiMapper::ofxPiMapper(){}
 
 void ofxPiMapper::setup(){

--- a/src/ofxPiMapper.cpp
+++ b/src/ofxPiMapper.cpp
@@ -1,5 +1,6 @@
 #include "ofxPiMapper.h"
 
+
 ofxPiMapper::ofxPiMapper(){}
 
 void ofxPiMapper::setup(){


### PR DESCRIPTION
Hi all, 

**first - as always - THANK YOU VERY MUCH for this aaaawesome piece of software**

this is a pull request for an old problem (absolute vs relative paths for sources): https://github.com/kr15h/ofxPiMapper/issues/115

The patch is not heavily tested nore am I a C++ developer. Still, I tested on Windows, Ubuntu and Raspi in basic example and it seems fine on first sight. 

Hope this helps.
oe