### PR TITLE
Add video sources control - restart/pause/resume

### DIFF
--- a/src/Application/Application.cpp
+++ b/src/Application/Application.cpp
@@ -652,5 +652,17 @@ void Application::toggleLayerPanel(){
 	}
 }
 
+void Application::restart(){
+	_mediaServer.restart();
+}
+
+void Application::pause(){
+	_mediaServer.pause();
+}
+
+void Application::resume(){
+	_mediaServer.resume();
+}
+
 } // namespace piMapper
 } // namespace ofx

--- a/src/Application/Application.h
+++ b/src/Application/Application.h
@@ -155,6 +155,11 @@ class Application {
 		void reboot();
 		void shutdown();
 
+		// video play control
+		void restart();
+		void pause();
+		void resume();
+
 	protected:
 		void setState(ApplicationBaseMode * st);
 

--- a/src/MediaServer/MediaServer.cpp
+++ b/src/MediaServer/MediaServer.cpp
@@ -57,6 +57,32 @@ void MediaServer::draw(){
 	}
 }
 
+void MediaServer::restart() {
+    typedef map <std::string, BaseSource *>::iterator it_type;
+    for(it_type i = loadedSources.begin(); i != loadedSources.end(); i++){
+        if(i->second->getType() == SourceType::SOURCE_TYPE_VIDEO){
+            static_cast <VideoSource *>(i->second)->restart();
+        }
+    }
+}
+void MediaServer::pause() {
+    typedef map <std::string, BaseSource *>::iterator it_type;
+    for(it_type i = loadedSources.begin(); i != loadedSources.end(); i++){
+        if(i->second->getType() == SourceType::SOURCE_TYPE_VIDEO){
+            static_cast <VideoSource *>(i->second)->pause();
+        }
+    }
+}
+void MediaServer::resume() {
+    typedef map <std::string, BaseSource *>::iterator it_type;
+    for(it_type i = loadedSources.begin(); i != loadedSources.end(); i++){
+        if(i->second->getType() == SourceType::SOURCE_TYPE_VIDEO){
+            static_cast <VideoSource *>(i->second)->resume();
+        }
+    }
+}
+
+
 int MediaServer::getNumImages(){
 	
 	return imageWatcher.getFilePaths().size();

--- a/src/MediaServer/MediaServer.h
+++ b/src/MediaServer/MediaServer.h
@@ -52,6 +52,10 @@ class MediaServer {
 		void update();
 		void draw();
 
+		void restart();
+		void pause();
+		void resume();
+
 		int getNumVideos();
 		int getNumImages();
 		int getNumFboSources(); // new

--- a/src/Sources/VideoSource.cpp
+++ b/src/Sources/VideoSource.cpp
@@ -106,5 +106,29 @@ void VideoSource::stop(){
 	}
 #endif
 
+void VideoSource::restart(){
+	#ifdef TARGET_RASPBERRY_PI
+		_omxPlayer->restartMovie();
+	#else
+		_videoPlayer->setPosition(0);
+		_videoPlayer->play();
+	#endif
+}
+
+void VideoSource::pause() {
+	#ifdef TARGET_RASPBERRY_PI
+		_omxPlayer->setPaused(true);
+	#else
+		_videoPlayer->setPaused(true);
+	#endif
+}
+void VideoSource::resume() {
+	#ifdef TARGET_RASPBERRY_PI
+		_omxPlayer->setPaused(false);
+	#else
+		_videoPlayer->setPaused(false);
+	#endif
+}
+
 } // namespace piMapper
 } // namespace ofx

--- a/src/Sources/VideoSource.h
+++ b/src/Sources/VideoSource.h
@@ -30,6 +30,9 @@ class VideoSource : public BaseSource {
         void togglePause();
         void stop();
 		void update(ofEventArgs & args);
+		void restart();
+		void pause();
+		void resume();
 
 	private:
 

--- a/src/ofxPiMapper.cpp
+++ b/src/ofxPiMapper.cpp
@@ -284,3 +284,15 @@ ofx::piMapper::Mode ofxPiMapper::getMode(){
 void ofxPiMapper::toggleLayerPanel(){
 	_application.toggleLayerPanel();
 }
+
+void ofxPiMapper::restart() {
+	_application.restart();
+}
+
+void ofxPiMapper::pause() {
+	_application.pause();
+}
+
+void ofxPiMapper::resume() {
+	_application.resume();
+}

--- a/src/ofxPiMapper.h
+++ b/src/ofxPiMapper.h
@@ -94,6 +94,11 @@ class ofxPiMapper {
 		void reboot();
 		void shutdown();
 
+		// video play control
+		void restart();
+		void pause();
+		void resume();
+
 	private:
 		ofx::piMapper::Application _application;
 };


### PR DESCRIPTION
Add methods that control all video sources in ofxPiMapper class.
- restart
- pause
- resume

restart function can make multiple raspberrypi play synchronized by calling it periodically 
