### PR TITLE
added 4 more FBO sources

### DIFF
--- a/example_fbo-sources/src/BrickSource/BrickSource.cpp
+++ b/example_fbo-sources/src/BrickSource/BrickSource.cpp
@@ -1,0 +1,52 @@
+#include "BrickSource.h"
+
+void BrickSource::setup(){
+	// Give our source a decent name
+	name = "Brick Source";
+
+	// Allocate our FBO source, decide how big it should be
+	allocate(500, 500);
+	ofSetFrameRate(60);
+
+	// Genereate rects to be rendered into the FBO
+	int numX = 21;
+	int numY = 21;  // change this to add more or less rects
+	int motar = 4;
+	int brickLength = 20;
+	int brickWidth = 20;
+	int counter = 0;
+	for(int k = 0; k < numY;k++){
+		for(int i = 0; i < numX; i++){
+
+			bricks.push_back(ofRectangle(i*(brickLength + motar),
+																	k*(brickWidth + motar),
+																	brickLength,
+																	brickWidth));
+			brickColor.push_back(ofRandom(0, 220));
+		}
+	}
+}
+
+// Don't do any drawing here
+void BrickSource::update(){
+	if (ofGetFrameNum()%30 == 0) {
+		for(int i = 0; i < bricks.size(); i++){
+		 brickColor[i] = ofRandom(0, 220);
+	 }
+	}	// Move quads
+}
+
+// No need to take care of fbo.begin() and fbo.end() here.
+// All within draw() is being rendered into fbo;
+void BrickSource::draw(){
+	// Fill FBO with our quads
+	ofClear(0);
+	//ofBackground(0);
+	ofFill();
+
+		for(int i = 0; i < bricks.size(); i++){
+			//ofSetLineWidth(ofRandom(5));
+			ofSetColor(brickColor[i]);
+			ofDrawRectangle(bricks[i]);
+		}
+}

--- a/example_fbo-sources/src/BrickSource/BrickSource.h
+++ b/example_fbo-sources/src/BrickSource/BrickSource.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "ofMain.h"
+#include "FboSource.h"
+
+class BrickSource : public ofx::piMapper::FboSource {
+	public:
+    void setup();
+		void update();
+		void draw();
+
+		std::vector<ofRectangle> bricks;
+		std::vector<int> brickColor;
+		int counter;
+};

--- a/example_fbo-sources/src/CircleSource/CircleSource.cpp
+++ b/example_fbo-sources/src/CircleSource/CircleSource.cpp
@@ -1,0 +1,43 @@
+#include "CircleSource.h"
+
+bool col = true;
+
+void CircleSource::setup(){
+	// Give our source a decent name
+	name = "Circle Source";
+
+	// Allocate our FBO source, decide how big it should be
+	allocate(500, 500);
+	ofSetCircleResolution(50);
+
+	// Genereate rects to be rendered into the FBO
+	int numCircles = 10;  // change this to add more or less rects
+	for(int i = 0; i < numCircles; i++){
+		circlesRadius.push_back(ofRandom(fbo->getHeight()/2));
+		circlesSpeeds.push_back((1.0f + ofRandom(2)));
+	}
+}
+
+// Don't do any drawing here
+void CircleSource::update(){
+	// Move rects
+	for(int i = 0; i < circlesRadius.size(); i++){
+		circlesRadius[i] += circlesSpeeds[i];
+		if(circlesRadius[i] > fbo->getHeight()/2){
+			circlesRadius[i] = fbo->getHeight()/2*(-1);
+		}
+	}
+}
+
+// No need to take care of fbo.begin() and fbo.end() here.
+// All within draw() is being rendered into fbo;
+void CircleSource::draw(){
+	// Fill FBO with our rects
+	ofClear(0);
+	ofSetColor(255);
+	ofSetLineWidth(ofRandom(3));
+	ofNoFill();
+		for(int i = 0; i < circlesRadius.size(); i++){
+			ofDrawCircle(fbo->getHeight()/2,fbo->getHeight()/2,circlesRadius[i]);
+		}
+}

--- a/example_fbo-sources/src/CircleSource/CircleSource.h
+++ b/example_fbo-sources/src/CircleSource/CircleSource.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "ofMain.h"
+#include "FboSource.h"
+
+class CircleSource : public ofx::piMapper::FboSource {
+	public:
+    void setup();
+		void update();
+		void draw();
+
+		std::vector<float> circlesRadius;
+		std::vector<float> circlesSpeeds;
+};

--- a/example_fbo-sources/src/QuadSource/QuadSource.cpp
+++ b/example_fbo-sources/src/QuadSource/QuadSource.cpp
@@ -1,0 +1,62 @@
+#include "QuadSource.h"
+
+void QuadSource::setup(){
+	// Give our source a decent name
+	name = "Quad Source";
+
+	// Allocate our FBO source, decide how big it should be
+	allocate(500, 500);
+
+	// Genereate rects to be rendered into the FBO
+	int numQuads = 20;  // change this to add more or less rects
+	for(int i = 0; i < numQuads; i++){
+		float qsize = ofRandom(fbo->getWidth());
+		float fbosize = fbo->getWidth();
+
+		quads.push_back(ofRectangle(fbosize/2 - qsize/2,
+																fbosize/2 - qsize/2,
+																qsize,
+																qsize));
+
+		quadSpeeds.push_back((1.0f + ofRandom(5)));
+	}
+}
+
+// Don't do any drawing here
+void QuadSource::update(){
+	// Move quads
+	for(int i = 0; i < quads.size(); i++){
+		quads[i].x -= quadSpeeds[i]/2;
+		quads[i].y -= quadSpeeds[i]/2;
+		quads[i].width += quadSpeeds[i];
+		quads[i].height += quadSpeeds[i];
+
+		if(quads[i].width > fbo->getHeight()){
+			quads[i].x = fbo->getWidth()/2;
+			quads[i].y = fbo->getWidth()/2;
+			quads[i].width = 0.0f;
+			quads[i].height = 0.0f;
+		}
+	}
+}
+
+// No need to take care of fbo.begin() and fbo.end() here.
+// All within draw() is being rendered into fbo;
+void QuadSource::draw(){
+	// Fill FBO with our quads
+	ofClear(0);
+	//ofBackground(0);
+	ofNoFill();
+	ofSetColor(255);
+
+	#if (OF_VERSION_MAJOR == 0 && OF_VERSION_MINOR >= 9) || OF_VERSION_MAJOR > 0
+		for(int i = 0; i < quads.size(); i++){
+			ofSetLineWidth(ofRandom(5));
+			ofDrawRectangle(quads[i]);
+		}
+	#else
+		for(int i = 0; i < quads.size(); i++){
+			ofRect(quads[i]);
+		}
+	#endif
+}

--- a/example_fbo-sources/src/QuadSource/QuadSource.h
+++ b/example_fbo-sources/src/QuadSource/QuadSource.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "ofMain.h"
+#include "FboSource.h"
+
+class QuadSource : public ofx::piMapper::FboSource {
+	public:
+    void setup();
+		void update();
+		void draw();
+
+		std::vector<ofRectangle> quads;
+		std::vector<float> quadSpeeds;
+};

--- a/example_fbo-sources/src/SyphonSource/SyphonSource.cpp
+++ b/example_fbo-sources/src/SyphonSource/SyphonSource.cpp
@@ -1,0 +1,87 @@
+// #include "SyphonSource.h"
+//
+// void SyphonSource::setup(){
+// 	// Give our source a decent name
+// 	name = "Syphon Source";
+//
+// 	// Allocate our FBO source, decide how big it should be
+// 	allocate(500, 500);
+//
+// 	//setup our directory
+// 	dir.setup();
+// 	//setup our client
+// 	mClient.setup();
+//
+// 	//register for our directory's callbacks
+// 	ofAddListener(dir.events.serverAnnounced, this, &SyphonSource::serverAnnounced);
+// 	// not yet implemented
+// 	//ofAddListener(dir.events.serverUpdated, this, &ofApp::serverUpdated);
+// 	ofAddListener(dir.events.serverRetired, this, &SyphonSource::serverRetired);
+//
+// 	dirIdx = -1;
+// }
+//
+// //these are our directory's callbacks
+// void SyphonSource::serverAnnounced(ofxSyphonServerDirectoryEventArgs &arg)
+// {
+// 	for( auto& dir : arg.servers ){
+// 			ofLogNotice("ofxSyphonServerDirectory Server Announced")<<" Server Name: "<<dir.serverName <<" | App Name: "<<dir.appName;
+// 	}
+// 	dirIdx = 0;
+// }
+//
+// void SyphonSource::serverUpdated(ofxSyphonServerDirectoryEventArgs &arg)
+// {
+// 	for( auto& dir : arg.servers ){
+// 			ofLogNotice("ofxSyphonServerDirectory Server Updated")<<" Server Name: "<<dir.serverName <<" | App Name: "<<dir.appName;
+// 	}
+// 	dirIdx = 0;
+// }
+//
+// void SyphonSource::serverRetired(ofxSyphonServerDirectoryEventArgs &arg)
+// {
+// 	for( auto& dir : arg.servers ){
+// 			ofLogNotice("ofxSyphonServerDirectory Server Retired")<<" Server Name: "<<dir.serverName <<" | App Name: "<<dir.appName;
+// 	}
+// 	dirIdx = 0;
+// }
+//
+//
+// // Don't do any drawing here
+// void SyphonSource::update(){
+//
+// }
+//
+// // No need to take care of fbo.begin() and fbo.end() here.
+// // All within draw() is being rendered into fbo;
+// void SyphonSource::draw(){
+// 	if(dir.isValidIndex(dirIdx))
+// 			mClient.draw(0, 0);
+// }
+//
+// //--------------------------------------------------------------
+// void SyphonSource::keyReleased(int key){
+//     //press any key to move through all available Syphon servers
+//     if (dir.size() > 0)
+//     {
+//         dirIdx++;
+//         if(dirIdx > dir.size() - 1)
+//             dirIdx = 0;
+//
+//         mClient.set(dir.getDescription(dirIdx));
+//         string serverName = mClient.getServerName();
+//         string appName = mClient.getApplicationName();
+//
+//         if(serverName == ""){
+//             serverName = "null";
+//         }
+//         if(appName == ""){
+//             appName = "null";
+//         }
+//         ofSetWindowTitle(serverName + ":" + appName);
+//     }
+//     else
+//     {
+//         ofSetWindowTitle("No Server");
+//     }
+// }

--- a/example_fbo-sources/src/SyphonSource/SyphonSource.h
+++ b/example_fbo-sources/src/SyphonSource/SyphonSource.h
@@ -1,0 +1,21 @@
+// #pragma once
+//
+// #include "ofMain.h"
+// #include "FboSource.h"
+// #include "ofxSyphon.h"
+// class SyphonSource : public ofx::piMapper::FboSource {
+// 	public:
+//     void setup();
+// 		void update();
+// 		void draw();
+//
+// 		void keyReleased(int key);
+//
+// 		void serverAnnounced(ofxSyphonServerDirectoryEventArgs &arg);
+// 		void serverUpdated(ofxSyphonServerDirectoryEventArgs &args);
+// 		void serverRetired(ofxSyphonServerDirectoryEventArgs &arg);
+//
+// 		ofxSyphonServerDirectory dir;
+// 		ofxSyphonClient mClient;
+// 		int dirIdx;
+// };

--- a/example_fbo-sources/src/ofApp.cpp
+++ b/example_fbo-sources/src/ofApp.cpp
@@ -10,8 +10,12 @@ void ofApp::setup(){
 
 	// Register our sources.
 	// This should be done before mapper.setup().
-	piMapper.registerFboSource(customSource);
-	piMapper.registerFboSource(slideShowSource);
+	piMapper.registerFboSource(ScanLSource);
+	piMapper.registerFboSource(QuadiSource);
+	piMapper.registerFboSource(CircLSource);
+	piMapper.registerFboSource(BricksSource);
+	//piMapper.registerFboSource(SyphonClient);
+	//piMapper.registerFboSource(slideShowSource);
 	piMapper.setup();
 
 	// This will set the app fullscreen if compiled on Raspberry Pi.
@@ -20,7 +24,7 @@ void ofApp::setup(){
 	#endif
 
 	// Start slideshow.
-    slideShowSource.play();
+    //slideShowSource.play();
 }
 
 void ofApp::update(){
@@ -40,6 +44,7 @@ void ofApp::keyReleased(int key){
 }
 
 void ofApp::mousePressed(int x, int y, int button){
+
 	piMapper.mousePressed(x, y, button);
 }
 

--- a/example_fbo-sources/src/ofApp.h
+++ b/example_fbo-sources/src/ofApp.h
@@ -4,6 +4,10 @@
 #include "ofxPiMapper.h"
 #include "VideoSource.h"
 #include "ScanlineSource.h"
+#include "CircleSource.h"
+#include "QuadSource.h"
+#include "BrickSource.h"
+//#include "SyphonSource.h"
 #include "magSlideShowSource.h"
 
 class ofApp : public ofBaseApp{
@@ -23,7 +27,11 @@ public:
 
     // By using a custom source that is derived from FboSource
     // you will be able to see the source listed in sources editor
-    ScanlineSource customSource;
+    ScanlineSource ScanLSource;
+    QuadSource QuadiSource;
+    CircleSource CircLSource;
+    BrickSource BricksSource;
+    //SyphonSource SyphonClient;
     magSlideShowSource slideShowSource;
 
 };


### PR DESCRIPTION
ScanlineSource ( was there already ) added CircleSource, QuadSource, BrickSource and SyphonSource (not visible).

<img width="659" alt="Bildschirmfoto 2022-07-27 um 02 05 39" src="https://user-images.githubusercontent.com/48415446/181289338-62709dc0-f975-443c-81b2-2d8c507258c5.png">


The SyphonFBO is disabled since it would not run on rpi.

[OSX only]
For Syphon to work you need to install ofxSyphon addon and add "ofxSyphon"
to the addons.make of ofxPiMapper. Then uncomment all the syphon lines in the code. So far the SyphonClient will choose the first Syphon source presented to him. ( You might want to start the server later ).